### PR TITLE
power ups implemented (sponge and first aid)

### DIFF
--- a/scenes/Rat.tscn
+++ b/scenes/Rat.tscn
@@ -16,7 +16,7 @@ animations = [ {
 radius = 18.9999
 height = 66.0002
 
-[node name="rat" type="RigidBody2D"]
+[node name="rat" type="RigidBody2D" groups=["rats"]]
 position = Vector2( 240, 0 )
 rotation = 1.56844
 gravity_scale = 0.0

--- a/scenes/main.tscn
+++ b/scenes/main.tscn
@@ -35,6 +35,8 @@ position = Vector2( 238, -40 )
 [connection signal="strike" from="Player" to="." method="_on_Player_strike"]
 [connection signal="update_health" from="Player" to="HUD" method="_on_Player_update_health"]
 [connection signal="timeout" from="MobTimer" to="." method="_on_MobTimer_timeout"]
+[connection signal="first_aid" from="power_ups" to="Player" method="_on_power_ups_first_aid"]
+[connection signal="sponge" from="power_ups" to="power_ups" method="_on_power_ups_sponge"]
 [connection signal="block" from="weapon_buttons" to="Player" method="_on_weapon_buttons_block"]
 [connection signal="broom" from="weapon_buttons" to="Player" method="_on_weapon_buttons_broom"]
 [connection signal="swing" from="weapon_buttons" to="Player" method="_on_weapon_buttons_swing"]

--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -7,7 +7,7 @@ signal update_health
 
 var player_health = 5
 var screen_size
-var current_action
+var current_action = 'walk'
 export var speed = 200
 
 
@@ -60,3 +60,8 @@ func _on_weapon_buttons_broom():
 
 func _on_Player_dead():
 	hide()
+
+
+func _on_power_ups_first_aid():
+	player_health = 5
+	emit_signal("update_health", player_health)

--- a/scripts/power_ups.gd
+++ b/scripts/power_ups.gd
@@ -11,14 +11,20 @@ func _ready():
 	
 func _on_FirstAid_pressed():
 	if firstaidcount == 0:
+		return
+	emit_signal("first_aid")
+	firstaidcount -= 1
+	if firstaidcount == 0:
 		$FirstAid.modulate = Color(255, 0, 0)
-	else:
-		emit_signal("first_aid")
-	firstaidcount -= 0
 
 func _on_Sponge_pressed():
 	if spongecount == 0:
+		return
+	emit_signal("sponge")
+	spongecount -= 1
+	if spongecount == 0:
 		$Sponge.modulate = Color(255, 0, 0)
-	else:
-		emit_signal("sponge")
-	spongecount -= 0
+
+
+func _on_power_ups_sponge():
+	get_tree().call_group("rats", "queue_free")


### PR DESCRIPTION
sponge clears all rats on screen and first aid refills the player's health to 5. fixed bug of player health not counting until broom is used. power ups turn red once fully used.